### PR TITLE
Enhance Ingress for Multiple Services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ kubeconfig*
 *.pem
 .env
 .coverage
+AWS.md
 
 # Ignore config at root, but allow examples
 .ephemeral-config.yaml

--- a/examples/.ephemeral-config.yaml
+++ b/examples/.ephemeral-config.yaml
@@ -1,22 +1,24 @@
 services:
   - name: frontend
-    image: nginx:latest
+    image: anthonydip/todo-frontend:latest
     port: 80
+    ingress:
+      enabled: true
+      path: "/"
+
   - name: backend
-    image: node:alpine
-    port: 3000
+    image: anthonydip/todo-backend:latest
+    port: 5000
+    ingress:
+      enabled: true
+      path: "/api"
     env:
-      NODE_ENV: production
-      API_URL: http://backend:3000
+      DATABASE_URL: postgresql://postgres:password@database:5432/todos
+      PORT: 5000
+
   - name: database
-    image: postgres:15
+    image: postgres:15-alpine
     port: 5432
     env:
-      POSTGRES_PASSWORD: mysecretpassword
-      POSTGRES_USER: myuser
-      POSTGRES_DB: mydb
-
-ingress:
-  enabled: true
-  service: frontend
-  port: 80
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: todos


### PR DESCRIPTION
Enables configurable ingress for each service from `.ephemeral-config.yaml`.

Closes #17 

## Changes
- Updated main.py to loop through services and create ingress per service
- Services now define their own ingress config (path, enabled)
- Supports multiple exposed services per namespace
- Removed global ingress config
- Updated `examples/.ephemeral-config.yaml`